### PR TITLE
fix: Use instancetype as return type

### DIFF
--- a/DJIWidget/VideoPreviewer/DJIVideoPreviewer.m
+++ b/DJIWidget/VideoPreviewer/DJIVideoPreviewer.m
@@ -272,13 +272,12 @@ DJIVideoDataFrameControlDelegate>{
 
 static DJIVideoPreviewer* previewer = nil;
 
-+(DJIVideoPreviewer*) instance
++ (instancetype)instance
 {
-    if(previewer == nil)
-    {
+    if(previewer == nil) {
         @synchronized (self) {
             if (previewer == nil) {
-                previewer = [[DJIVideoPreviewer alloc] init];
+                previewer = [[self alloc] init];
                 previewer.isDefaultPreviewer = YES;
             }
         }


### PR DESCRIPTION
`DJIVideoPreviewer` 中的 `instance` 方法中，返回类型以及初始化类型都写死了，不利于外部功能扩展（继承）。因此建议将两者改成业内更通用的做法。