### PR TITLE
The declaration of method instance not consistent with its implementation

### DIFF
--- a/DJIWidget/VideoPreviewer/DJIVideoPreviewer.h
+++ b/DJIWidget/VideoPreviewer/DJIVideoPreviewer.h
@@ -145,7 +145,7 @@ typedef NS_ENUM(NSUInteger, DJIVideoPreviewerType){
 /**
  *  get default previewer
  */
-+(DJIVideoPreviewer*) instance;
++ (instancetype)instance;
 
 // SDK
 /**


### PR DESCRIPTION
The declaration of `instance` in `DJIVideoPreviewer.h` is:
```Objective-C
+ (DJIVideoPreviewer *)instance;
```
While its implementation in `.m` file is:
```Objective-C
+ (instancetype)instance {
...
}
```
Whose return type is not consistent.