### PR TITLE
Fix a memory leak due to captured strong self and a retain cycle

### DIFF
--- a/DJIWidget/VideoPreviewer/Render/Base/DJILiveViewRenderContext.m
+++ b/DJIWidget/VideoPreviewer/Render/Base/DJILiveViewRenderContext.m
@@ -52,7 +52,7 @@
                                                  usingBlock:^(NSNotification *notification) {
         __typeof__ (self) strongSelf = weakSelf;
         if (strongSelf) {
-            CVOpenGLESTextureCacheFlush([self coreVideoTextureCache], 0);
+            CVOpenGLESTextureCacheFlush([strongSelf coreVideoTextureCache], 0);
         }
     }];
     

--- a/DJIWidget/VideoPreviewer/Render/Base/DJILiveViewRenderProgram.h
+++ b/DJIWidget/VideoPreviewer/Render/Base/DJILiveViewRenderProgram.h
@@ -20,7 +20,7 @@
 
 @property(readwrite, nonatomic) BOOL initialized;
 @property(readonly, nonatomic) BOOL released;
-@property(readonly, nonatomic) DJILiveViewRenderContext* context;
+@property(weak, readonly, nonatomic) DJILiveViewRenderContext* context;
 @property(readwrite, copy, nonatomic) NSString *vertexShaderLog;
 @property(readwrite, copy, nonatomic) NSString *fragmentShaderLog;
 @property(readwrite, copy, nonatomic) NSString *programLog;


### PR DESCRIPTION
- Don't use `self` in a capturing block
- Use `weak` for an unowned object